### PR TITLE
Make sure repository is mounted before configuration is reloaded

### DIFF
--- a/docs/03_stratum1_proxies.md
+++ b/docs/03_stratum1_proxies.md
@@ -366,11 +366,11 @@ CVMFS_HTTP_PROXY="http://<PROXY_IP>:3128"
 
 ***Replace the ``<PROXY_IP>`` part with the IP address of your Squid proxy server!***
 
-After changing the local configuration file, unmount and probe the repository to enable the new configuration:
+After changing the local configuration file, make sure the repository is mounted (e.g. by doing an `ls`) and reload the configuration:
 
 ```bash
-sudo cvmfs_config umount repo.organization.tld
-sudo cvmfs_config probe repo.organization.tld
+ls /cvmfs/repo.organization.tld
+sudo cvmfs_config reload repo.organization.tld
 ```
 
 More proxies can be added to `CVMFS_HTTP_PROXY` by separating them with a pipe symbol.

--- a/docs/03_stratum1_proxies.md
+++ b/docs/03_stratum1_proxies.md
@@ -366,13 +366,14 @@ CVMFS_HTTP_PROXY="http://<PROXY_IP>:3128"
 
 ***Replace the ``<PROXY_IP>`` part with the IP address of your Squid proxy server!***
 
-After changing the local configuration file, make sure to reload the CernVM-FS client configuration:
+After changing the local configuration file, unmount and probe the repository to enable the new configuration:
 
 ```bash
-sudo cvmfs_config reload repo.organization.tld
+sudo cvmfs_config umount repo.organization.tld
+sudo cvmfs_config probe repo.organization.tld
 ```
 
-More proxies can be added to that list by separating them with a pipe symbol.
+More proxies can be added to `CVMFS_HTTP_PROXY` by separating them with a pipe symbol.
 
 For more (complex) examples, see the [CernVM-FS documentation](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#proxy-list-examples).
 


### PR DESCRIPTION
If the repository was automatically unmounted by `autofs` after a period of inactivity, reloading the config results in an error:
```
$ sudo cvmfs_config reload sw.eb.org
Connecting to CernVM-FS loader... failed!
```

Instead, we can explicitly unmount, and then "reload" by doing a probe:
```
$ sudo cvmfs_config umount sw.eb.org
$ sudo cvmfs_config probe sw.eb.org
Probing /cvmfs/sw.eb.org... OK
```