### PR TITLE
Fixed ingest command invocation.

### DIFF
--- a/docs/04_publishing.md
+++ b/docs/04_publishing.md
@@ -59,7 +59,7 @@ in CernVM-FS versions prior to 2.8.0 (see [here](https://github.com/cvmfs/cvmfs/
 In case you have a compressed tarball, you can use an appropriate decompression tool and write the output to `stdout`.
 This output can then be piped to `cvmfs_server` command while passing '`-`' to the `-t` option. For example, for a `.tar.gz` file:
 ```bash
-gunzip -c mytarball.tar.gz | cvmfs_server ingest -b some/path -t -
+gunzip -c mytarball.tar.gz | cvmfs_server ingest -t - -b some/path repo.organization.tld
 ```
 
 


### PR DESCRIPTION
The following did not work for me:
```
gunzip -c cvmfs-tutorial-ingest-example-720k-files.tar.gz | sudo cvmfs_server ingest -b easybuild repo.organization.tld -t -
The repository - does not exist.
```

But this did: 
```
gunzip -c cvmfs-tutorial-ingest-example-720k-files.tar.gz | sudo cvmfs_server ingest -t - -b easybuild repo.organization.tld
```

Did someone else get this error?